### PR TITLE
disable `@typescript-eslint/no-unused-expressions` for svelte

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # changelog
 
+## 0.1.1
+
+- disable `@typescript-eslint/no-unused-expressions` for svelte
+  ([#2](https://github.com/feltcoop/eslint-config/pull/2))
+
 ## 0.1.0
 
-- publish (#1)
+- publish
+  ([#1](https://github.com/feltcoop/eslint-config/pull/1))

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.1.1
 
-- disable `@typescript-eslint/no-unused-expressions` for svelte
+- disable `@typescript-eslint/no-unused-expressions` for Svelte
   ([#2](https://github.com/feltcoop/eslint-config/pull/2))
 
 ## 0.1.0

--- a/index.cjs
+++ b/index.cjs
@@ -102,10 +102,6 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: ['*.svelte'],
-			processor: 'svelte3/svelte3',
-		},
-		{
 			files: ['*.ts', '*.svelte'],
 			rules: {
 				'@typescript-eslint/adjacent-overload-signatures': 1,
@@ -182,6 +178,11 @@ module.exports = {
 					{path: 'never', types: 'never', lib: 'never'},
 				],
 			},
+		},
+		{
+			files: ['*.svelte'],
+			processor: 'svelte3/svelte3',
+			rules: {'@typescript-eslint/no-unused-expressions': 0},
 		},
 	],
 };


### PR DESCRIPTION
A common idiom in Svelte is:

```svelte
$: someReactiveValue, doSomething();
```

To ESLint, the `someReactiveValue` part looks useless per the rule `@typescript-eslint/no-unused-expressions`. This disables it just for Svelte.