### PR TITLE
add extraFileExtensions default

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,7 @@ Then add the following to your project's `package.json` or an
 {
 	"eslintConfig": {
 		"root": true,
-		"extends": "@feltcoop",
-		"parserOptions": {
-			"project": ["./tsconfig.json"]
-		}
+		"extends": "@feltcoop"
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ Then add the following to your project's `package.json` or an
 		"root": true,
 		"extends": "@feltcoop",
 		"parserOptions": {
-			"project": ["./tsconfig.json"],
-			"extraFileExtensions": [".svelte"]
+			"project": ["./tsconfig.json"]
 		}
 	}
 }

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 
 ## 0.1.3
 
-- add default `parserOptions.extraFileExtensions` for Svelte so user configs don't need it
+- add default `parserOptions.extraFileExtensions` and `parserOptions.project`
+  for Svelte so user configs don't need it
   ([#4](https://github.com/feltcoop/eslint-config/pull/4))
 
 ## 0.1.2

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.1.3
+
+- add default `parserOptions.extraFileExtensions` for Svelte so user configs don't need it
+  ([#4](https://github.com/feltcoop/eslint-config/pull/4))
+
 ## 0.1.2
 
 - disable `no-multi-assign`

--- a/index.cjs
+++ b/index.cjs
@@ -8,6 +8,7 @@ module.exports = {
 	parserOptions: {
 		ecmaVersion: 'latest',
 		sourceType: 'module',
+		extraFileExtensions: ['.svelte'],
 	},
 	plugins: ['@typescript-eslint', 'svelte3'],
 	settings: {

--- a/index.cjs
+++ b/index.cjs
@@ -9,6 +9,7 @@ module.exports = {
 		ecmaVersion: 'latest',
 		sourceType: 'module',
 		extraFileExtensions: ['.svelte'],
+		project: ['./tsconfig.json'],
 	},
 	plugins: ['@typescript-eslint', 'svelte3'],
 	settings: {

--- a/index.cjs
+++ b/index.cjs
@@ -8,8 +8,8 @@ module.exports = {
 	parserOptions: {
 		ecmaVersion: 'latest',
 		sourceType: 'module',
-		extraFileExtensions: ['.svelte'],
 		project: ['./tsconfig.json'],
+		extraFileExtensions: ['.svelte'],
 	},
 	plugins: ['@typescript-eslint', 'svelte3'],
 	settings: {


### PR DESCRIPTION
Adds the default `extraFileExtensions` for Svelte to the config so user projects don't have to define it.