### PR TITLE
report unused disable directives

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.1.4
+
+- enable `reportUnusedDisableDirectives`
+  ([#5](https://github.com/feltcoop/eslint-config/pull/5))
+
 ## 0.1.3
 
 - add default `parserOptions.extraFileExtensions` and `parserOptions.project`

--- a/index.cjs
+++ b/index.cjs
@@ -15,6 +15,7 @@ module.exports = {
 	settings: {
 		'svelte3/typescript': true,
 	},
+	reportUnusedDisableDirectives: true,
 	rules: {
 		// eslint possible problems
 		'array-callback-return': 1,


### PR DESCRIPTION
Enables `reportUnusedDisableDirectives` so useless comments get cleaned up.

see <https://eslint.org/docs/user-guide/configuring/rules#report-unused-eslint-disable-comments>