### PR TITLE
disable no-lonely-if

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.1.5
+
+- disable `no-lonely-if`
+  ([#6](https://github.com/feltcoop/eslint-config/pull/6))
+
 ## 0.1.4
 
 - enable `reportUnusedDisableDirectives`

--- a/index.cjs
+++ b/index.cjs
@@ -60,7 +60,6 @@ module.exports = {
 		'no-extra-boolean-cast': 1,
 		'no-global-assign': 1,
 		'no-lone-blocks': 1,
-		'no-lonely-if': 1,
 		'no-multi-str': 1,
 		'no-new': 1,
 		'no-new-func': 1, // catches cases missed by @typescript-eslint/no-implied-eval


### PR DESCRIPTION
Disables [`no-lonely-if`](https://eslint.org/docs/rules/no-lonely-if). Seems it can impede clarity and doesn't add much value.