### PR TITLE
disable `@typescript-eslint/no-restricted-imports`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.1.6
+
+- disable `@typescript-eslint/no-restricted-imports`
+  ([#8](https://github.com/feltcoop/eslint-config/pull/8))
+
 ## 0.1.5
 
 - disable `no-lonely-if`

--- a/index.cjs
+++ b/index.cjs
@@ -140,18 +140,6 @@ module.exports = {
 				'@typescript-eslint/no-non-null-asserted-nullish-coalescing': 1,
 				'@typescript-eslint/no-non-null-asserted-optional-chain': 1,
 				'@typescript-eslint/no-require-imports': 1,
-				'@typescript-eslint/no-restricted-imports': [
-					1,
-					{
-						paths: [
-							{
-								name: 'fs',
-								message: "Please use 'fs-extra' instead, or a local `fs` argument if available.",
-								allowTypeImports: true,
-							},
-						],
-					},
-				],
 				'@typescript-eslint/no-this-alias': 1,
 				'@typescript-eslint/no-throw-literal': 1,
 				'@typescript-eslint/no-unnecessary-boolean-literal-compare': 1,


### PR DESCRIPTION
This was an oversight, when written I wasn't thinking this project would be used by others.