### PR TITLE
upgrade to latest rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ in your config:
 
 See [index.cjs](index.cjs) and the [ESLint docs](https://eslint.org/).
 
+Rules are current through `eslint@8.20.0` and `@typescript-eslint/eslint-plugin@5.30.7`.
+
 ## publish
 
 First update the [changelog](changelog.md) with a helpful summary of changes, then:

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,8 @@
 # changelog
 
-## 0.1.8
+## 0.2.0
 
-- upgrade to `eslint@8.20.0` and `@typescript-eslint/eslint-plugin@5.30.7`
+- **break**: upgrade rules to `eslint@8.20.0` and `@typescript-eslint/eslint-plugin@5.30.7`
   ([#10](https://github.com/feltcoop/eslint-config/pull/10))
 
 ## 0.1.7

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.1.8
+
+- upgrade to `eslint@8.20.0` and `@typescript-eslint/eslint-plugin@5.30.7`
+  ([#10](https://github.com/feltcoop/eslint-config/pull/10))
+
 ## 0.1.7
 
 - disable `no-else-return`

--- a/index.cjs
+++ b/index.cjs
@@ -126,6 +126,7 @@ module.exports = {
 				'@typescript-eslint/no-empty-function': 1,
 				'@typescript-eslint/no-empty-interface': 1,
 				'@typescript-eslint/no-extra-non-null-assertion': 1,
+				'@typescript-eslint/no-duplicate-enum-values': 1,
 				'@typescript-eslint/no-floating-promises': [1, {ignoreIIFE: true}],
 				'@typescript-eslint/no-for-in-array': 1,
 				'@typescript-eslint/no-implied-eval': 1,
@@ -143,7 +144,8 @@ module.exports = {
 				'@typescript-eslint/no-this-alias': 1,
 				'@typescript-eslint/no-throw-literal': 1,
 				'@typescript-eslint/no-unnecessary-boolean-literal-compare': 1,
-				'@typescript-eslint/no-unnecessary-type-assertion': 1,
+				// TODO is erroring with eslint@8.20.0 and @typescript-eslint/eslint-plugin@5.30.7 -- Cannot read properties of undefined (reading 'kind')
+				// '@typescript-eslint/no-unnecessary-type-assertion': 1,
 				'@typescript-eslint/no-unnecessary-type-constraint': 1,
 				'@typescript-eslint/no-unused-expressions': [
 					1,

--- a/index.cjs
+++ b/index.cjs
@@ -123,7 +123,7 @@ module.exports = {
 				'@typescript-eslint/no-array-constructor': 1,
 				'@typescript-eslint/no-base-to-string': 1,
 				'@typescript-eslint/no-duplicate-imports': 1,
-				'@typescript-eslint/no-empty-function': 1,
+				'@typescript-eslint/no-empty-function': [1, {allow: ['overrideMethods']}],
 				'@typescript-eslint/no-empty-interface': 1,
 				'@typescript-eslint/no-extra-non-null-assertion': 1,
 				'@typescript-eslint/no-duplicate-enum-values': 1,

--- a/index.cjs
+++ b/index.cjs
@@ -53,6 +53,7 @@ module.exports = {
 		'grouped-accessor-pairs': [1, 'getBeforeSet'],
 		'no-alert': 1, // <3 these but often they're for testing; make explicit w/ eslint-ignore-line
 		'no-case-declarations': 1,
+		'no-constant-binary-expression': 1,
 		// 'no-else-return': 1, // a bit too opinionated
 		'no-empty': [1, {allowEmptyCatch: true}],
 		'no-eval': 1,

--- a/index.cjs
+++ b/index.cjs
@@ -122,7 +122,7 @@ module.exports = {
 				'@typescript-eslint/method-signature-style': 1,
 				'@typescript-eslint/no-array-constructor': 1,
 				'@typescript-eslint/no-base-to-string': 1,
-				'@typescript-eslint/no-duplicate-imports': 1,
+				'@typescript-eslint/no-duplicate-imports': 1, // TODO deprecated for https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-duplicates.md
 				'@typescript-eslint/no-empty-function': [1, {allow: ['overrideMethods']}],
 				'@typescript-eslint/no-empty-interface': 1,
 				'@typescript-eslint/no-extra-non-null-assertion': 1,

--- a/index.cjs
+++ b/index.cjs
@@ -159,6 +159,7 @@ module.exports = {
 				'@typescript-eslint/prefer-regexp-exec': 1,
 				'@typescript-eslint/prefer-string-starts-ends-with': 1,
 				'@typescript-eslint/prefer-ts-expect-error': 1,
+				'@typescript-eslint/no-redundant-type-constituents': 1,
 				'@typescript-eslint/require-array-sort-compare': [1, {ignoreStringArrays: true}],
 				'@typescript-eslint/return-await': 1,
 				'@typescript-eslint/switch-exhaustiveness-check': 1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.7",
       "license": "Unlicense",
       "devDependencies": {
-        "prettier": "^2.5.1"
+        "prettier": "^2.7.1"
       },
       "engines": {
         "node": ">= 16.6"
@@ -1192,15 +1192,18 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {
@@ -2371,9 +2374,9 @@
       "peer": true
     },
     "prettier": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
     "punycode": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "deploy": "gro deploy"
   },
   "devDependencies": {
-    "prettier": "^2.5.1"
+    "prettier": "^2.7.1"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": ">=5",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@typescript-eslint/parser": ">=5",
     "eslint": ">=8",
     "eslint-plugin-svelte3": ">=3",
-    "typescript": ">=4"
+    "typescript": ">=4.7"
   },
   "prettier": {
     "useTabs": true,


### PR DESCRIPTION
Left a couple TODOs, seems `@typescript-eslint/no-unnecessary-type-assertion` is bugged and  `@typescript-eslint/no-duplicate-imports` is deprecated.