### PR TITLE
disable overrideMethods option for `@typescript-eslint/no-empty-function` temporarily

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.2.1
+
+- disable the `overrideMethods` option for `@typescript-eslint/no-empty-function` temporarily
+  ([#11](https://github.com/feltcoop/eslint-config/pull/11))
+
 ## 0.2.0
 
 - **break**: upgrade rules to `eslint@8.20.0` and `@typescript-eslint/eslint-plugin@5.30.7`

--- a/index.cjs
+++ b/index.cjs
@@ -124,7 +124,7 @@ module.exports = {
 				'@typescript-eslint/no-array-constructor': 1,
 				'@typescript-eslint/no-base-to-string': 1,
 				'@typescript-eslint/no-duplicate-imports': 1, // TODO deprecated for https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-duplicates.md
-				'@typescript-eslint/no-empty-function': [1, {allow: ['overrideMethods']}],
+				'@typescript-eslint/no-empty-function': 1, // TODO eslint is currently throwing an error with this: `{allow: ['overrideMethods']}`
 				'@typescript-eslint/no-empty-interface': 1,
 				'@typescript-eslint/no-extra-non-null-assertion': 1,
 				'@typescript-eslint/no-duplicate-enum-values': 1,


### PR DESCRIPTION
ESLint is loudly complaining in vscode about `{allow: ['overrideMethods']}` for `@typescript-eslint/no-empty-function` so I'm disabling it for now.